### PR TITLE
Fix chart bug

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -82,8 +82,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # ユーザにつき、デフォルトのアイテムを12個作成する
   def generate_default_items_for(user)
-    12.times do |i|
-      user.items.create(name: "項目#{i + 1}")
-    end
+    user.set_twelve_items
   end
 end

--- a/app/helpers/item_helper.rb
+++ b/app/helpers/item_helper.rb
@@ -1,7 +1,7 @@
 module ItemHelper
   COLORS = %w[#D896AD #ECA2A3 #F1B996 #F6D699 #E3DE9A #A6D29A #93C7B7 #92BFC7 #90B0CA #B5A4C7 #B5A4C7 #C59DBB]
 
-  # itemを引数に取り, userがもつ何個目のitemであるかを返す。(1-based index)
+  # itemを引数に取り, userがもつ何個目(1..12)のitemであるかを返す。(1-based index)
   def item_num(item)
     user_items = item.user.items.get_fixed_order
     user_items.pluck(:id).find_index(item.id) + 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,11 @@ class User < ApplicationRecord
 
   has_many :items, dependent: :destroy
   has_many :logs, through: :items, dependent: :destroy
+
+
+  def set_twelve_items
+    12.times do |i|
+      items.create(name: "項目#{i + 1}")
+    end
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,6 @@
 <h3 class="text-start pb-1 my-3 border-bottom border-2"><%= @item.name %>の履歴</h3>
 <div class='chart mb-5'>
-  <%= line_chart @item.logs.group_by_week('logs.created_at').sum('logs.amount / 60'), colors: [item_color(@item)], curve: false, suffix: "時間" %>
+  <%= line_chart @item.logs.group_by_week('logs.created_at', last: 8).sum('logs.amount / 60'), colors: [item_color(@item)], curve: false, suffix: "時間" %>
 </div>
 <div class="row">
   <div class="col-md-4">

--- a/app/views/statistics/line.html.erb
+++ b/app/views/statistics/line.html.erb
@@ -13,8 +13,8 @@
   <div class="card-body">
     <%= line_chart  @items.map { |item|
   { name: item.name,
-    data: item.logs.group_by_month('logs.created_at', format: 
-    '%m月').sum('logs.amount / 60') }
+    data: item.logs.group_by_month('logs.created_at',  last: 3,
+    format: '%m月').sum('logs.amount / 60') }
   }, stacked: true, suffix: "時間", curve: false%>
   </div>
 </div>

--- a/app/views/statistics/pie.html.erb
+++ b/app/views/statistics/pie.html.erb
@@ -11,7 +11,7 @@
     </ul>
   </div>
   <div class="card-body">
-    <%= pie_chart  @items.order(:id).map { |item|
+    <%= pie_chart  @items.map { |item|
     [item.name, item.logs.sum('amount / 60')]
    }, suffix: "時間" %>
   </div>

--- a/spec/heplers/item_helper_spec.rb
+++ b/spec/heplers/item_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ItemHelper, type: :helper do
+
+  it 'item_num' do
+    user = FactoryBot.create(:user, :with_items)
+    twelfth_item = user.items.last
+    expect(helper.item_num(twelfth_item)).to eq 12
+  end
+end


### PR DESCRIPTION
新規ユーザがログを持たないために、line chart描画のx軸の範囲が指定できない。というエラーを修正しました。

修正の内容としては、last: ?で表示するタイムラインを限定することで、明示的にrangeを指定しました。
将来的には、月別、年別でのページの切り替えもしたいです。