### PR TITLE
guestログインのバグをfix

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -13,7 +13,7 @@
       <div class="d-grid gap-2 col-6 mx-auto">
         <%= link_to "新規登録", new_user_registration_path, class: "btn btn-secondary"%>
         <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline-secondary"%>
-        <%= link_to "ゲストとしてアプリを試す", guest_path %>
+        <%= link_to "ゲストとしてアプリを試す", guest_path, method: :post %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   get '/privacy_policy', to: 'static_pages#privacy'
   get '/terms_of_service', to: 'static_pages#service'
   root 'static_pages#home'
-  get '/guest', to: 'users#guest'
+  post '/guest', to: 'users#guest'
 
   namespace :charts do
     get 'all_lines'


### PR DESCRIPTION
guestログインのlink_toメソッドをpostリクエストを送信するように変更しました。
コントローラでのredirectが正常に動作するようになりました。